### PR TITLE
fix: Corrige a sintaxe do diagrama Mermaid no README

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,7 @@ flowchart TD
 
     M[shared] --> N[exception]
     M --> O[utils]
-
----
-`
-
+```
 
 # 🗄️ Banco de Dados - Cardápio Digital
 


### PR DESCRIPTION
O bloco de código do diagrama Mermaid continha caracteres extras (--- e `) que impediam a sua correta renderização no GitHub.

Esta correção remove os caracteres desnecessários, permitindo que o diagrama de arquitetura seja exibido como pretendido.