### PR TITLE
feat: Implement user registration service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,15 @@
 			<artifactId>h2</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.5.0</version>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/comanda_digital/application/dto/UsuarioRequestDTO.java
+++ b/src/main/java/com/comanda_digital/application/dto/UsuarioRequestDTO.java
@@ -1,0 +1,27 @@
+package com.comanda_digital.application.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsuarioRequestDTO implements Serializable {
+
+    @NotBlank(message = "O nome é obrigatório")
+    private String nome;
+
+    @NotBlank(message = "O email é obrigatório")
+    @Email(message = "Email inválido")
+    private String email;
+
+    @NotBlank(message = "A senha é obrigatória")
+    private String senha;
+
+    private String telefone;
+}

--- a/src/main/java/com/comanda_digital/application/dto/UsuarioResponseDTO.java
+++ b/src/main/java/com/comanda_digital/application/dto/UsuarioResponseDTO.java
@@ -1,0 +1,21 @@
+package com.comanda_digital.application.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class UsuarioResponseDTO implements Serializable {
+
+    private Long id;
+    private String nome;
+    private String email;
+    private String telefone;
+    private String status;
+    private LocalDateTime dataCriacao;
+}

--- a/src/main/java/com/comanda_digital/application/port/UsuarioServicePort.java
+++ b/src/main/java/com/comanda_digital/application/port/UsuarioServicePort.java
@@ -1,0 +1,8 @@
+package com.comanda_digital.application.port;
+
+import com.comanda_digital.application.dto.UsuarioRequestDTO;
+import com.comanda_digital.application.dto.UsuarioResponseDTO;
+
+public interface UsuarioServicePort {
+    UsuarioResponseDTO cadastrarUsuario(UsuarioRequestDTO usuarioRequestDTO);
+}

--- a/src/main/java/com/comanda_digital/application/service/UsuarioServiceImpl.java
+++ b/src/main/java/com/comanda_digital/application/service/UsuarioServiceImpl.java
@@ -1,0 +1,66 @@
+package com.comanda_digital.application.service;
+
+import com.comanda_digital.application.dto.UsuarioRequestDTO;
+import com.comanda_digital.application.dto.UsuarioResponseDTO;
+import com.comanda_digital.application.port.UsuarioServicePort;
+import com.comanda_digital.domain.model.Usuario;
+import com.comanda_digital.infrastructure.persistence.UsuarioRepository;
+import com.comanda_digital.shared.exception.EmailAlreadyExistsException;
+import org.springframework.stereotype.Service;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Service
+public class UsuarioServiceImpl implements UsuarioServicePort {
+
+    private final UsuarioRepository usuarioRepository;
+
+    public UsuarioServiceImpl(UsuarioRepository usuarioRepository) {
+        this.usuarioRepository = usuarioRepository;
+    }
+
+    @Override
+    public UsuarioResponseDTO cadastrarUsuario(UsuarioRequestDTO usuarioRequestDTO) {
+        Optional<Usuario> existingUser = usuarioRepository.findByEmail(usuarioRequestDTO.getEmail());
+        if (existingUser.isPresent()) {
+            throw new EmailAlreadyExistsException("O email '" + usuarioRequestDTO.getEmail() + "' já está cadastrado.");
+        }
+
+        Usuario usuario = new Usuario();
+        usuario.setNome(usuarioRequestDTO.getNome());
+        usuario.setEmail(usuarioRequestDTO.getEmail());
+        usuario.setSenha(hashPassword(usuarioRequestDTO.getSenha()));
+        usuario.setTelefone(usuarioRequestDTO.getTelefone());
+        usuario.setStatus("ATIVO");
+        usuario.setDataCriacao(LocalDateTime.now());
+
+        Usuario savedUsuario = usuarioRepository.save(usuario);
+
+        return new UsuarioResponseDTO(
+                savedUsuario.getId(),
+                savedUsuario.getNome(),
+                savedUsuario.getEmail(),
+                savedUsuario.getTelefone(),
+                savedUsuario.getStatus(),
+                savedUsuario.getDataCriacao()
+        );
+    }
+
+    private String hashPassword(String password) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-512");
+            byte[] hashedBytes = md.digest(password.getBytes(StandardCharsets.UTF_8));
+            StringBuilder sb = new StringBuilder();
+            for (byte b : hashedBytes) {
+                sb.append(String.format("%02x", b));
+            }
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Erro ao fazer hash da senha", e);
+        }
+    }
+}

--- a/src/main/java/com/comanda_digital/infrastructure/persistence/UsuarioRepository.java
+++ b/src/main/java/com/comanda_digital/infrastructure/persistence/UsuarioRepository.java
@@ -4,6 +4,9 @@ import com.comanda_digital.domain.model.Usuario;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface UsuarioRepository extends JpaRepository<Usuario, Long> {
+    Optional<Usuario> findByEmail(String email);
 }

--- a/src/main/java/com/comanda_digital/infrastructure/rest/UsuarioController.java
+++ b/src/main/java/com/comanda_digital/infrastructure/rest/UsuarioController.java
@@ -1,0 +1,37 @@
+package com.comanda_digital.infrastructure.rest;
+
+import com.comanda_digital.application.dto.UsuarioRequestDTO;
+import com.comanda_digital.application.dto.UsuarioResponseDTO;
+import com.comanda_digital.application.port.UsuarioServicePort;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/usuarios")
+@Tag(name = "Usuários", description = "Operações relacionadas a usuários")
+public class UsuarioController {
+
+    private final UsuarioServicePort usuarioServicePort;
+
+    public UsuarioController(UsuarioServicePort usuarioServicePort) {
+        this.usuarioServicePort = usuarioServicePort;
+    }
+
+    @Operation(summary = "Cadastra um novo usuário", description = "Cria um novo usuário no sistema")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "Usuário cadastrado com sucesso"),
+            @ApiResponse(responseCode = "400", description = "Dados de entrada inválidos"),
+            @ApiResponse(responseCode = "409", description = "Email já cadastrado")
+    })
+    @PostMapping
+    public ResponseEntity<UsuarioResponseDTO> cadastrarUsuario(@Valid @RequestBody UsuarioRequestDTO usuarioRequestDTO) {
+        UsuarioResponseDTO responseDTO = usuarioServicePort.cadastrarUsuario(usuarioRequestDTO);
+        return new ResponseEntity<>(responseDTO, HttpStatus.CREATED);
+    }
+}

--- a/src/main/java/com/comanda_digital/shared/exception/EmailAlreadyExistsException.java
+++ b/src/main/java/com/comanda_digital/shared/exception/EmailAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package com.comanda_digital.shared.exception;
+
+public class EmailAlreadyExistsException extends RuntimeException {
+    public EmailAlreadyExistsException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/comanda_digital/shared/exception/ErrorResponse.java
+++ b/src/main/java/com/comanda_digital/shared/exception/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.comanda_digital.shared.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class ErrorResponse {
+    private int statusCode;
+    private String message;
+    private LocalDateTime timestamp;
+    private List<String> details;
+}

--- a/src/main/java/com/comanda_digital/shared/exception/RestExceptionHandler.java
+++ b/src/main/java/com/comanda_digital/shared/exception/RestExceptionHandler.java
@@ -1,0 +1,55 @@
+package com.comanda_digital.shared.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RestControllerAdvice
+public class RestExceptionHandler {
+
+    @ExceptionHandler(EmailAlreadyExistsException.class)
+    public ResponseEntity<ErrorResponse> handleEmailAlreadyExistsException(EmailAlreadyExistsException ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.CONFLICT.value(),
+                "Conflict",
+                LocalDateTime.now(),
+                Collections.singletonList(ex.getMessage())
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.CONFLICT);
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationExceptions(MethodArgumentNotValidException ex) {
+        List<String> details = ex.getBindingResult()
+                .getAllErrors()
+                .stream()
+                .map(error -> error.getDefaultMessage())
+                .collect(Collectors.toList());
+
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.BAD_REQUEST.value(),
+                "Validation Failed",
+                LocalDateTime.now(),
+                details
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ErrorResponse> handleGenericException(Exception ex) {
+        ErrorResponse errorResponse = new ErrorResponse(
+                HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                "An unexpected error occurred",
+                LocalDateTime.now(),
+                Collections.singletonList(ex.getMessage())
+        );
+        return new ResponseEntity<>(errorResponse, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,13 @@
 spring.application.name=comanda-digital
+
+# Conexão com o banco PostgreSQL
+spring.datasource.url=jdbc:postgresql://localhost:5432/cardapio_db
+spring.datasource.username=cardapio_user
+spring.datasource.password=cardapio_pass
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# JPA/Hibernate
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect


### PR DESCRIPTION
- Adds a REST endpoint POST /usuarios for user registration.
- Implements the service layer with business logic, including email duplication check and SHA-512 password hashing.
- Creates DTOs for request and response, ensuring the password is not exposed.
- Adds custom exception handling for validation and business rule violations.
- Integrates Swagger/OpenAPI for API documentation.
- Adds necessary dependencies for validation and Swagger.